### PR TITLE
Add scala-2.12 support

### DIFF
--- a/scalap-compiler-deps/2.12.1/build.sbt
+++ b/scalap-compiler-deps/2.12.1/build.sbt
@@ -1,0 +1,41 @@
+import sbt.Keys._
+
+scalaVersion := "2.12.1"
+
+publishMavenStyle := true
+publishArtifact := true
+publishArtifact in Test := true
+publishArtifact in (Compile, packageDoc) := true
+publishArtifact in (Test, packageDoc) := true
+pomIncludeRepository := { _ => false }
+publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+homepage := Some(url("https://github.com/twitter/finatra"))
+autoAPIMappings := true
+apiURL := Some(url("https://twitter.github.io/finatra/docs/"))
+pomExtra := (
+<scm>
+  <url>git://github.com/twitter/finatra.git</url>
+  <connection>scm:git://github.com/twitter/finatra.git</connection>
+</scm>
+<developers>
+  <developer>
+    <id>twitter</id>
+    <name>Twitter Inc.</name>
+    <url>https://www.twitter.com/</url>
+  </developer>
+</developers>
+)
+
+lazy val root = (project in file(".")).
+  settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-reflect" % "2.12.1"
+    ),
+    version := "2.0.0",
+    resolvers ++= Seq(),
+    organization := "com.twitter.finatra",
+    moduleName := "finatra-scalap-compiler-deps")

--- a/scalap-compiler-deps/2.12.1/project/build.properties
+++ b/scalap-compiler-deps/2.12.1/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9

--- a/scalap-compiler-deps/2.12.1/project/plugins.sbt
+++ b/scalap-compiler-deps/2.12.1/project/plugins.sbt
@@ -1,0 +1,4 @@
+resolvers ++= Seq(
+  Classpaths.sbtPluginSnapshots,
+  Classpaths.sbtPluginReleases
+)

--- a/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package scala.tools.nsc.classpath
+
+import scala.reflect.io.AbstractFile
+import scala.tools.nsc.util.ClassPath
+
+/**
+ * A trait that contains factory methods for classpath elements of type T.
+ *
+ * The logic has been abstracted from ClassPath#ClassPathContext so it's possible
+ * to have common trait that supports both recursive and flat classpath representations.
+ *
+ * Therefore, we expect that T will be either ClassPath[U] or FlatClassPath.
+ */
+trait ClassPathFactory[T] {
+
+  /**
+   * Create a new classpath based on the abstract file.
+   */
+  def newClassPath(file: AbstractFile): T
+
+  /**
+   * Creators for sub classpaths which preserve this context.
+   */
+  def sourcesInPath(path: String): List[T]
+
+  def expandPath(path: String, expandStar: Boolean = true): List[String] = ClassPath.expandPath(path, expandStar)
+
+  def expandDir(extdir: String): List[String] = ClassPath.expandDir(extdir)
+
+  def contentsOfDirsInPath(path: String): List[T] =
+    for {
+      dir <- expandPath(path, expandStar = false)
+      name <- expandDir(dir)
+      entry <- Option(AbstractFile.getDirectory(name))
+    } yield newClassPath(entry)
+
+  def classesInExpandedPath(path: String): IndexedSeq[T] =
+    classesInPathImpl(path, expand = true).toIndexedSeq
+
+  def classesInPath(path: String) = classesInPathImpl(path, expand = false)
+
+  def classesInManifest(useManifestClassPath: Boolean) =
+    if (useManifestClassPath) ClassPath.manifests.map(url => newClassPath(AbstractFile getResources url))
+    else Nil
+
+  // Internal
+  protected def classesInPathImpl(path: String, expand: Boolean) =
+    for {
+      file <- expandPath(path, expand)
+      dir <- Option(AbstractFile.getDirectory(file))
+    } yield newClassPath(dir)
+}

--- a/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/classpath/FileUtils.scala
+++ b/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/classpath/FileUtils.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package scala.tools.nsc.classpath
+
+import java.io.{ File => JFile }
+import java.net.URL
+import scala.reflect.internal.FatalError
+import scala.reflect.io.AbstractFile
+
+/**
+ * Common methods related to Java files and abstract files used in the context of classpath
+ */
+object FileUtils {
+  implicit class AbstractFileOps(val file: AbstractFile) extends AnyVal {
+    def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.name)
+
+    def isClass: Boolean = !file.isDirectory && file.hasExtension("class")
+
+    def isScalaOrJavaSource: Boolean = !file.isDirectory && (file.hasExtension("scala") || file.hasExtension("java"))
+
+    // TODO do we need to check also other files using ZipMagicNumber like in scala.tools.nsc.io.Jar.isJarOrZip?
+    def isJarOrZip: Boolean = file.hasExtension("jar") || file.hasExtension("zip")
+
+    /**
+     * Safe method returning a sequence containing one URL representing this file, when underlying file exists,
+     * and returning given default value in other case
+     */
+    def toURLs(default: => Seq[URL] = Seq.empty): Seq[URL] = if (file.file == null) default else Seq(file.toURL)
+  }
+
+  implicit class FileOps(val file: JFile) extends AnyVal {
+    def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.getName)
+
+    def isClass: Boolean = file.isFile && file.getName.endsWith(".class")
+  }
+
+  def stripSourceExtension(fileName: String): String = {
+    if (endsScala(fileName)) stripClassExtension(fileName)
+    else if (endsJava(fileName)) stripJavaExtension(fileName)
+    else throw new FatalError("Unexpected source file ending: " + fileName)
+  }
+
+  def dirPath(forPackage: String) = forPackage.replace('.', '/')
+
+  def endsClass(fileName: String): Boolean =
+    fileName.length > 6 && fileName.substring(fileName.length - 6) == ".class"
+
+  def endsScalaOrJava(fileName: String): Boolean =
+    endsScala(fileName) || endsJava(fileName)
+
+  def endsJava(fileName: String): Boolean =
+    fileName.length > 5 && fileName.substring(fileName.length - 5) == ".java"
+
+  def endsScala(fileName: String): Boolean =
+    fileName.length > 6 && fileName.substring(fileName.length - 6) == ".scala"
+
+  def stripClassExtension(fileName: String): String =
+    fileName.substring(0, fileName.length - 6) // equivalent of fileName.length - ".class".length
+
+  def stripJavaExtension(fileName: String): String =
+    fileName.substring(0, fileName.length - 5)
+
+  // probably it should match a pattern like [a-z_]{1}[a-z0-9_]* but it cannot be changed
+  // because then some tests in partest don't pass
+  private def mayBeValidPackage(dirName: String): Boolean =
+    (dirName != "META-INF") && (dirName != "") && (dirName.charAt(0) != '.')
+}

--- a/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/io/Jar.scala
+++ b/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/io/Jar.scala
@@ -1,0 +1,170 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author  Paul Phillips
+ */
+
+package scala.tools.nsc
+package io
+
+import java.io.{ InputStream, OutputStream, IOException, FileNotFoundException, FileInputStream, DataOutputStream }
+import java.util.jar._
+import scala.collection.JavaConverters._
+import Attributes.Name
+import scala.language.{ implicitConversions, postfixOps }
+
+// Attributes.Name instances:
+//
+// static Attributes.Name   CLASS_PATH
+// static Attributes.Name   CONTENT_TYPE
+// static Attributes.Name   EXTENSION_INSTALLATION
+// static Attributes.Name   EXTENSION_LIST
+// static Attributes.Name   EXTENSION_NAME
+// static Attributes.Name   IMPLEMENTATION_TITLE
+// static Attributes.Name   IMPLEMENTATION_URL
+// static Attributes.Name   IMPLEMENTATION_VENDOR
+// static Attributes.Name   IMPLEMENTATION_VENDOR_ID
+// static Attributes.Name   IMPLEMENTATION_VERSION
+// static Attributes.Name   MAIN_CLASS
+// static Attributes.Name   MANIFEST_VERSION
+// static Attributes.Name   SEALED
+// static Attributes.Name   SIGNATURE_VERSION
+// static Attributes.Name   SPECIFICATION_TITLE
+// static Attributes.Name   SPECIFICATION_VENDOR
+// static Attributes.Name   SPECIFICATION_VERSION
+
+class Jar(file: File) extends Iterable[JarEntry] {
+  def this(jfile: JFile) = this(File(jfile))
+  def this(path: String) = this(File(path))
+
+  lazy val manifest = withJarInput(s => Option(s.getManifest))
+
+  def mainClass     = manifest map (f => f(Name.MAIN_CLASS))
+  /** The manifest-defined classpath String if available. */
+  def classPathString: Option[String] =
+    for (m <- manifest ; cp <- m.attrs get Name.CLASS_PATH) yield cp
+  def classPathElements: List[String] = classPathString match {
+    case Some(s)  => s split "\\s+" toList
+    case _        => Nil
+  }
+
+  /** Invoke f with input for named jar entry (or None). */
+  def withEntryStream[A](name: String)(f: Option[InputStream] => A) = {
+    val jarFile = new JarFile(file.jfile)
+    def apply() =
+      jarFile getEntry name match {
+        case null   => f(None)
+        case entry  =>
+          val in = Some(jarFile getInputStream entry)
+          try f(in)
+          finally in map (_.close())
+      }
+    try apply() finally jarFile.close()
+  }
+
+  def withJarInput[T](f: JarInputStream => T): T = {
+    val in = new JarInputStream(file.inputStream())
+    try f(in)
+    finally in.close()
+  }
+  def jarWriter(mainAttrs: (Attributes.Name, String)*) = {
+    new JarWriter(file, Jar.WManifest(mainAttrs: _*).underlying)
+  }
+
+  override def foreach[U](f: JarEntry => U): Unit = withJarInput { in =>
+    Iterator continually in.getNextJarEntry() takeWhile (_ != null) foreach f
+  }
+  override def iterator: Iterator[JarEntry] = this.toList.iterator
+  override def toString = "" + file
+}
+
+class JarWriter(val file: File, val manifest: Manifest) {
+  private lazy val out = new JarOutputStream(file.outputStream(), manifest)
+
+  /** Adds a jar entry for the given path and returns an output
+   *  stream to which the data should immediately be written.
+   *  This unusual interface exists to work with fjbg.
+   */
+  def newOutputStream(path: String): DataOutputStream = {
+    val entry = new JarEntry(path)
+    out putNextEntry entry
+    new DataOutputStream(out)
+  }
+
+  def writeAllFrom(dir: Directory) {
+    try dir.list foreach (x => addEntry(x, ""))
+    finally out.close()
+  }
+  def addStream(entry: JarEntry, in: InputStream) {
+    out putNextEntry entry
+    try transfer(in, out)
+    finally out.closeEntry()
+  }
+  def addFile(file: File, prefix: String) {
+    val entry = new JarEntry(prefix + file.name)
+    addStream(entry, file.inputStream())
+  }
+  def addEntry(entry: Path, prefix: String) {
+    if (entry.isFile) addFile(entry.toFile, prefix)
+    else addDirectory(entry.toDirectory, prefix + entry.name + "/")
+  }
+  def addDirectory(entry: Directory, prefix: String) {
+    entry.list foreach (p => addEntry(p, prefix))
+  }
+
+  private def transfer(in: InputStream, out: OutputStream) = {
+    val buf = new Array[Byte](10240)
+    def loop(): Unit = in.read(buf, 0, buf.length) match {
+      case -1 => in.close()
+      case n  => out.write(buf, 0, n) ; loop()
+    }
+    loop()
+  }
+
+  def close() = out.close()
+}
+
+object Jar {
+  type AttributeMap = java.util.Map[Attributes.Name, String]
+
+  object WManifest {
+    def apply(mainAttrs: (Attributes.Name, String)*): WManifest = {
+      val m = WManifest(new JManifest)
+      for ((k, v) <- mainAttrs)
+        m(k) = v
+
+      m
+    }
+    def apply(manifest: JManifest): WManifest = new WManifest(manifest)
+  }
+  class WManifest(manifest: JManifest) {
+    for ((k, v) <- initialMainAttrs)
+      this(k) = v
+
+    def underlying = manifest
+    def attrs = manifest.getMainAttributes().asInstanceOf[AttributeMap].asScala withDefaultValue null
+    def initialMainAttrs: Map[Attributes.Name, String] = {
+      import scala.util.Properties._
+      Map(
+        Name.MANIFEST_VERSION -> "1.0",
+        ScalaCompilerVersion  -> versionNumberString
+      )
+    }
+
+    def apply(name: Attributes.Name): String        = attrs(name)
+    def update(key: Attributes.Name, value: String) = attrs.put(key, value)
+  }
+
+  // See http://download.java.net/jdk7/docs/api/java/nio/file/Path.html
+  // for some ideas.
+  private val ZipMagicNumber = List[Byte](80, 75, 3, 4)
+  private def magicNumberIsZip(f: Path) = f.isFile && (f.toFile.bytes().take(4).toList == ZipMagicNumber)
+
+  def isJarOrZip(f: Path): Boolean = isJarOrZip(f, examineFile = true)
+  def isJarOrZip(f: Path, examineFile: Boolean): Boolean =
+    f.hasExtension("zip", "jar") || (examineFile && magicNumberIsZip(f))
+
+  def create(file: File, sourceDir: Directory, mainClass: String) {
+    val writer = new Jar(file).jarWriter(Name.MAIN_CLASS -> mainClass)
+    writer writeAllFrom sourceDir
+  }
+}

--- a/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/io/package.scala
+++ b/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/io/package.scala
@@ -1,0 +1,30 @@
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author Paul Phillips
+ */
+
+package scala.tools.nsc
+
+import scala.language.implicitConversions
+
+package object io {
+  // Forwarders from scala.reflect.io
+  type AbstractFile = scala.reflect.io.AbstractFile
+  val AbstractFile = scala.reflect.io.AbstractFile
+  type Directory = scala.reflect.io.Directory
+  val Directory = scala.reflect.io.Directory
+  type File = scala.reflect.io.File
+  val File = scala.reflect.io.File
+  type Path = scala.reflect.io.Path
+  val Path = scala.reflect.io.Path
+  type PlainFile = scala.reflect.io.PlainFile
+  val Streamable = scala.reflect.io.Streamable
+  type VirtualDirectory = scala.reflect.io.VirtualDirectory
+  type VirtualFile = scala.reflect.io.VirtualFile
+  type ZipArchive = scala.reflect.io.ZipArchive
+
+  type JManifest = java.util.jar.Manifest
+  type JFile = java.io.File
+
+  implicit def enrichManifest(m: JManifest): Jar.WManifest = Jar.WManifest(m)
+}

--- a/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/util/ClassFileLookup.scala
+++ b/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/util/ClassFileLookup.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2014 Contributor. All rights reserved.
+ */
+package scala.tools.nsc.util
+
+import scala.tools.nsc.io.AbstractFile
+import java.net.URL
+
+/**
+ * Simple interface that allows us to abstract over how class file lookup is performed
+ * in different classpath representations.
+ */
+// TODO at the end, after the possible removal of the old classpath representation, this class shouldn't be generic
+// T should be just changed to AbstractFile
+trait ClassFileLookup[T] {
+  def findClassFile(name: String): Option[AbstractFile]
+
+  /**
+   * It returns both classes from class file and source files (as our base ClassRepresentation).
+   * So note that it's not so strictly related to findClassFile.
+   */
+  def findClass(name: String): Option[ClassRepresentation[T]]
+
+  /**
+   * A sequence of URLs representing this classpath.
+   */
+  def asURLs: Seq[URL]
+
+  /** The whole classpath in the form of one String.
+    */
+  def asClassPathString: String
+
+  // for compatibility purposes
+  @deprecated("Use asClassPathString instead of this one", "2.11.5")
+  def asClasspathString: String = asClassPathString
+
+  /** The whole sourcepath in the form of one String.
+    */
+  def asSourcePathString: String
+}
+
+/**
+ * Represents classes which can be loaded with a ClassfileLoader and/or SourcefileLoader.
+ */
+// TODO at the end, after the possible removal of the old classpath implementation, this class shouldn't be generic
+// T should be just changed to AbstractFile
+trait ClassRepresentation[T] {
+  def binary: Option[T]
+  def source: Option[AbstractFile]
+
+  def name: String
+}
+
+object ClassRepresentation {
+  def unapply[T](classRep: ClassRepresentation[T]): Option[(Option[T], Option[AbstractFile])] =
+    Some((classRep.binary, classRep.source))
+}

--- a/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/util/ClassPath.scala
+++ b/scalap-compiler-deps/2.12.1/src/main/scala/scala/tools/nsc/util/ClassPath.scala
@@ -1,0 +1,397 @@
+/* NSC -- new Scala compiler
+ * Copyright 2006-2013 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+
+
+package scala.tools.nsc
+package util
+
+import io.{ AbstractFile, Directory, File, Jar }
+import java.net.MalformedURLException
+import java.net.URL
+import java.util.regex.PatternSyntaxException
+import scala.collection.{ mutable, immutable }
+import scala.reflect.internal.FatalError
+import scala.reflect.internal.util.StringOps.splitWhere
+import scala.tools.nsc.classpath.FileUtils
+
+import File.pathSeparator
+import FileUtils.endsClass
+import FileUtils.endsScalaOrJava
+import Jar.isJarOrZip
+
+/** <p>
+ *    This module provides star expansion of '-classpath' option arguments, behaves the same as
+ *    java, see [http://java.sun.com/javase/6/docs/technotes/tools/windows/classpath.html]
+ *  </p>
+ *
+ *  @author Stepan Koltsov
+ */
+object ClassPath {
+  import scala.language.postfixOps
+
+  /** Expand single path entry */
+  private def expandS(pattern: String): List[String] = {
+    val wildSuffix = File.separator + "*"
+
+    /* Get all subdirectories, jars, zips out of a directory. */
+    def lsDir(dir: Directory, filt: String => Boolean = _ => true) =
+      dir.list filter (x => filt(x.name) && (x.isDirectory || isJarOrZip(x))) map (_.path) toList
+
+    if (pattern == "*") lsDir(Directory("."))
+    else if (pattern endsWith wildSuffix) lsDir(Directory(pattern dropRight 2))
+    else if (pattern contains '*') {
+      try {
+        val regexp = ("^" + pattern.replaceAllLiterally("""\*""", """.*""") + "$").r
+        lsDir(Directory(pattern).parent, regexp findFirstIn _ isDefined)
+      }
+      catch { case _: PatternSyntaxException => List(pattern) }
+    }
+    else List(pattern)
+  }
+
+  /** Split classpath using platform-dependent path separator */
+  def split(path: String): List[String] = (path split pathSeparator).toList filterNot (_ == "") distinct
+
+  /** Join classpath using platform-dependent path separator */
+  def join(paths: String*): String  = paths filterNot (_ == "") mkString pathSeparator
+
+  /** Split the classpath, apply a transformation function, and reassemble it. */
+  def map(cp: String, f: String => String): String = join(split(cp) map f: _*)
+
+  /** Expand path and possibly expanding stars */
+  def expandPath(path: String, expandStar: Boolean = true): List[String] =
+    if (expandStar) split(path) flatMap expandS
+    else split(path)
+
+  /** Expand dir out to contents, a la extdir */
+  def expandDir(extdir: String): List[String] = {
+    AbstractFile getDirectory extdir match {
+      case null => Nil
+      case dir  => dir filter (_.isClassContainer) map (x => new java.io.File(dir.file, x.name) getPath) toList
+    }
+  }
+  /** Expand manifest jar classpath entries: these are either urls, or paths
+   *  relative to the location of the jar.
+   */
+  def expandManifestPath(jarPath: String): List[URL] = {
+    val file = File(jarPath)
+    if (!file.isFile) return Nil
+
+    val baseDir = file.parent
+    new Jar(file).classPathElements map (elem =>
+      specToURL(elem) getOrElse (baseDir / elem).toURL
+    )
+  }
+
+  def specToURL(spec: String): Option[URL] =
+    try Some(new URL(spec))
+    catch { case _: MalformedURLException => None }
+
+  /** A class modeling aspects of a ClassPath which should be
+   *  propagated to any classpaths it creates.
+   */
+  abstract class ClassPathContext[T] extends classpath.ClassPathFactory[ClassPath[T]] {
+    /** A filter which can be used to exclude entities from the classpath
+     *  based on their name.
+     */
+    def isValidName(name: String): Boolean = true
+
+    /** Filters for assessing validity of various entities.
+     */
+    def validClassFile(name: String)  = endsClass(name) && isValidName(name)
+    def validPackage(name: String)    = (name != "META-INF") && (name != "") && (name.charAt(0) != '.')
+    def validSourceFile(name: String) = endsScalaOrJava(name)
+
+    /** From the representation to its identifier.
+     */
+    def toBinaryName(rep: T): String
+
+    def sourcesInPath(path: String): List[ClassPath[T]] =
+      for (file <- expandPath(path, expandStar = false) ; dir <- Option(AbstractFile getDirectory file)) yield
+        new SourcePath[T](dir, this)
+  }
+
+  def manifests: List[java.net.URL] = {
+    import scala.collection.convert.WrapAsScala.enumerationAsScalaIterator
+    Thread.currentThread().getContextClassLoader()
+      .getResources("META-INF/MANIFEST.MF")
+      .filter(_.getProtocol == "jar").toList
+  }
+
+  class JavaContext extends ClassPathContext[AbstractFile] {
+    def toBinaryName(rep: AbstractFile) = {
+      val name = rep.name
+      assert(endsClass(name), name)
+      FileUtils.stripClassExtension(name)
+    }
+
+    def newClassPath(dir: AbstractFile) = new DirectoryClassPath(dir, this)
+  }
+
+  object DefaultJavaContext extends JavaContext
+
+  /** From the source file to its identifier.
+   */
+  def toSourceName(f: AbstractFile): String = FileUtils.stripSourceExtension(f.name)
+}
+
+import ClassPath._
+
+/**
+ * Represents a package which contains classes and other packages
+ */
+abstract class ClassPath[T] extends ClassFileLookup[T] {
+  /**
+   * The short name of the package (without prefix)
+   */
+  def name: String
+
+  /**
+   * A String representing the origin of this classpath element, if known.
+   * For example, the path of the directory or jar.
+   */
+  def origin: Option[String] = None
+
+  /** Info which should be propagated to any sub-classpaths.
+   */
+  def context: ClassPathContext[T]
+
+  /** Lists of entities.
+   */
+  def classes: IndexedSeq[ClassRepresentation[T]]
+  def packages: IndexedSeq[ClassPath[T]]
+  def sourcepaths: IndexedSeq[AbstractFile]
+
+  /** The entries this classpath is composed of. In class `ClassPath` it's just the singleton list containing `this`.
+   *  Subclasses such as `MergedClassPath` typically return lists with more elements.
+   */
+  def entries: IndexedSeq[ClassPath[T]] = IndexedSeq(this)
+
+  /** Merge classpath of `platform` and `urls` into merged classpath */
+  def mergeUrlsIntoClassPath(urls: URL*): MergedClassPath[T] = {
+    // Collect our new jars/directories and add them to the existing set of classpaths
+    val allEntries =
+      (entries ++
+       urls.map(url => context.newClassPath(io.AbstractFile.getURL(url)))
+      ).distinct
+
+    // Combine all of our classpaths (old and new) into one merged classpath
+    new MergedClassPath(allEntries, context)
+  }
+
+  /**
+   * Represents classes which can be loaded with a ClassfileLoader and/or SourcefileLoader.
+   */
+  case class ClassRep(binary: Option[T], source: Option[AbstractFile]) extends ClassRepresentation[T] {
+    def name: String = binary match {
+      case Some(x)  => context.toBinaryName(x)
+      case _        =>
+        assert(source.isDefined)
+        toSourceName(source.get)
+    }
+  }
+
+  /** Filters for assessing validity of various entities.
+   */
+  def validClassFile(name: String)  = context.validClassFile(name)
+  def validPackage(name: String)    = context.validPackage(name)
+  def validSourceFile(name: String) = context.validSourceFile(name)
+
+  /**
+   * Find a ClassRep given a class name of the form "package.subpackage.ClassName".
+   * Does not support nested classes on .NET
+   */
+  override def findClass(name: String): Option[ClassRepresentation[T]] =
+    splitWhere(name, _ == '.', doDropIndex = true) match {
+      case Some((pkg, rest)) =>
+        val rep = packages find (_.name == pkg) flatMap (_ findClass rest)
+        rep map {
+          case x: ClassRepresentation[T] => x
+          case x            => throw new FatalError("Unexpected ClassRep '%s' found searching for name '%s'".format(x, name))
+        }
+      case _ =>
+        classes find (_.name == name)
+    }
+
+  override def findClassFile(name: String): Option[AbstractFile] =
+    findClass(name) match {
+      case Some(ClassRepresentation(Some(x: AbstractFile), _)) => Some(x)
+      case _                                        => None
+    }
+
+  override def asSourcePathString: String = sourcepaths.mkString(pathSeparator)
+
+  def sortString = join(split(asClassPathString).sorted: _*)
+  override def equals(that: Any) = that match {
+    case x: ClassPath[_]  => this.sortString == x.sortString
+    case _                => false
+  }
+  override def hashCode = sortString.hashCode()
+}
+
+/**
+ * A Classpath containing source files
+ */
+class SourcePath[T](dir: AbstractFile, val context: ClassPathContext[T]) extends ClassPath[T] {
+  import FileUtils.AbstractFileOps
+
+  def name = dir.name
+  override def origin = dir.underlyingSource map (_.path)
+  def asURLs = dir.toURLs()
+  def asClassPathString = dir.path
+  val sourcepaths: IndexedSeq[AbstractFile] = IndexedSeq(dir)
+
+  private def traverse() = {
+    val classBuf   = immutable.Vector.newBuilder[ClassRep]
+    val packageBuf = immutable.Vector.newBuilder[SourcePath[T]]
+    dir foreach { f =>
+      if (!f.isDirectory && validSourceFile(f.name))
+        classBuf += ClassRep(None, Some(f))
+      else if (f.isDirectory && validPackage(f.name))
+        packageBuf += new SourcePath[T](f, context)
+    }
+    (packageBuf.result(), classBuf.result())
+  }
+
+  lazy val (packages, classes) = traverse()
+  override def toString() = "sourcepath: "+ dir.toString()
+}
+
+/**
+ * A directory (or a .jar file) containing classfiles and packages
+ */
+class DirectoryClassPath(val dir: AbstractFile, val context: ClassPathContext[AbstractFile]) extends ClassPath[AbstractFile] {
+  import FileUtils.AbstractFileOps
+
+  def name = dir.name
+  override def origin = dir.underlyingSource map (_.path)
+  def asURLs = dir.toURLs(default = Seq(new URL(name)))
+  def asClassPathString = dir.path
+  val sourcepaths: IndexedSeq[AbstractFile] = IndexedSeq()
+
+  // calculates (packages, classes) in one traversal.
+  private def traverse() = {
+    val classBuf   = immutable.Vector.newBuilder[ClassRep]
+    val packageBuf = immutable.Vector.newBuilder[DirectoryClassPath]
+    dir foreach {
+      f =>
+        // Optimization: We assume the file was not changed since `dir` called
+        // `Path.apply` and categorized existent files as `Directory`
+        // or `File`.
+        val isDirectory = f match {
+          case pf: io.PlainFile => pf.givenPath match {
+            case _: io.Directory => true
+            case _: io.File      => false
+            case _               => f.isDirectory
+          }
+          case _ =>
+            f.isDirectory
+        }
+        if (!isDirectory && validClassFile(f.name))
+          classBuf += ClassRep(Some(f), None)
+        else if (isDirectory && validPackage(f.name))
+          packageBuf += new DirectoryClassPath(f, context)
+    }
+    (packageBuf.result(), classBuf.result())
+  }
+
+  lazy val (packages, classes) = traverse()
+  override def toString() = "directory classpath: "+ origin.getOrElse("?")
+}
+
+class DeltaClassPath[T](original: MergedClassPath[T], subst: Map[ClassPath[T], ClassPath[T]])
+extends MergedClassPath[T](original.entries map (e => subst getOrElse (e, e)), original.context) {
+  // not sure we should require that here. Commented out for now.
+  // require(subst.keySet subsetOf original.entries.toSet)
+  // We might add specialized operations for computing classes packages here. Not sure it's worth it.
+}
+
+/**
+ * A classpath unifying multiple class- and sourcepath entries.
+ */
+class MergedClassPath[T](
+  override val entries: IndexedSeq[ClassPath[T]],
+  val context: ClassPathContext[T])
+extends ClassPath[T] {
+
+  def this(entries: TraversableOnce[ClassPath[T]], context: ClassPathContext[T]) =
+    this(entries.toIndexedSeq, context)
+
+  def name = entries.head.name
+  def asURLs = (entries flatMap (_.asURLs)).toList
+  lazy val sourcepaths: IndexedSeq[AbstractFile] = entries flatMap (_.sourcepaths)
+
+  override def origin = Some(entries map (x => x.origin getOrElse x.name) mkString ("Merged(", ", ", ")"))
+  override def asClassPathString: String = join(entries map (_.asClassPathString) : _*)
+
+  lazy val classes: IndexedSeq[ClassRepresentation[T]] = {
+    var count   = 0
+    val indices = mutable.HashMap[String, Int]()
+    val cls     = new mutable.ArrayBuffer[ClassRepresentation[T]](1024)
+
+    for (e <- entries; c <- e.classes) {
+      val name = c.name
+      if (indices contains name) {
+        val idx      = indices(name)
+        val existing = cls(idx)
+
+        if (existing.binary.isEmpty && c.binary.isDefined)
+          cls(idx) = ClassRep(binary = c.binary, source = existing.source)
+        if (existing.source.isEmpty && c.source.isDefined)
+          cls(idx) = ClassRep(binary = existing.binary, source = c.source)
+      }
+      else {
+        indices(name) = count
+        cls += c
+        count += 1
+      }
+    }
+    cls.toIndexedSeq
+  }
+
+  lazy val packages: IndexedSeq[ClassPath[T]] = {
+    var count   = 0
+    val indices = mutable.HashMap[String, Int]()
+    val pkg     = new mutable.ArrayBuffer[ClassPath[T]](256)
+
+    for (e <- entries; p <- e.packages) {
+      val name = p.name
+      if (indices contains name) {
+        val idx  = indices(name)
+        pkg(idx) = addPackage(pkg(idx), p)
+      }
+      else {
+        indices(name) = count
+        pkg += p
+        count += 1
+      }
+    }
+    pkg.toIndexedSeq
+  }
+
+  private def addPackage(to: ClassPath[T], pkg: ClassPath[T]) = {
+    val newEntries: IndexedSeq[ClassPath[T]] = to match {
+      case cp: MergedClassPath[_] => cp.entries :+ pkg
+      case _                      => IndexedSeq(to, pkg)
+    }
+    new MergedClassPath[T](newEntries, context)
+  }
+
+  def show() {
+    println("ClassPath %s has %d entries and results in:\n".format(name, entries.size))
+    asClassPathString split ':' foreach (x => println("  " + x))
+  }
+
+  override def toString() = "merged classpath "+ entries.mkString("(", "\n", ")")
+}
+
+/**
+ * The classpath when compiling with target:jvm. Binary files (classfiles) are represented
+ * as AbstractFile. nsc.io.ZipArchive is used to view zip/jar archives as directories.
+ */
+class JavaClassPath(
+  containers: IndexedSeq[ClassPath[AbstractFile]],
+  context: JavaContext)
+extends MergedClassPath[AbstractFile](containers, context) { }


### PR DESCRIPTION
Problem

Finatra has a dependency on this project publishing a scala-2.12 compatible artifact

Solution

Add scala 2.12.1 module

Result

Unblocking finatra scala-2.12 upgrade

cc @mosesn
Related to: https://github.com/twitter/finatra/issues/323